### PR TITLE
Revert "add kibana auth secret"

### DIFF
--- a/templates/es-cleanup.yml
+++ b/templates/es-cleanup.yml
@@ -37,18 +37,6 @@ objects:
                 value: ${SRE_MANAGED}
               - name: RET_DAYS
                 value: ${RET_DAYS}
-              - name: USER
-                valueFrom:
-                  secretKeyRef:
-                    key: username
-                    name: admin_user_credentials
-                required: false
-              - name: PASSWORD
-                valueFrom:
-                  secretKeyRef:
-                    key: password
-                    name: admin_user_credentials
-                required: false
               name: es-cleanup 
               resources: 
                 requests:


### PR DESCRIPTION
`Invalid value: "admin_user_credentials": a lowercase RFC 1123 subdomain must consist of lower case alphanumeric characters, '-' or '.', and must start and end with an alphanumeric character (e.g. 'example.com', regex used for validation is '[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*')`